### PR TITLE
fix: iterate pollfds properly and not coppying parser strings

### DIFF
--- a/includes/Parser.hpp
+++ b/includes/Parser.hpp
@@ -5,6 +5,6 @@
 
 class Parser {
    public:
-    static std::string readFile(const std::string& filename);
-    static std::string extractWord(std::string& str);
+    static void readFile(const std::string& filename, std::string& buf);
+    static void extractWord(std::string& str, std::string& buf);
 };

--- a/srcs/Client.cpp
+++ b/srcs/Client.cpp
@@ -73,7 +73,8 @@ void Client::handlePollin(int index) {
     this->_header = request.substr(0, headerEnd);
     this->_body = request.substr(headerEnd + 4);
 
-    std::string method = Parser::extractWord(this->_header);
+    std::string method;
+    Parser::extractWord(this->_header, method);
 
     if (method == "GET")
         getMethod();

--- a/srcs/Config.cpp
+++ b/srcs/Config.cpp
@@ -6,12 +6,13 @@
 #include "Parser.hpp"
 
 Config::Config(std::string& fileContent) {
-    std::string word = Parser::extractWord(fileContent);
+    std::string word;
+    Parser::extractWord(fileContent, word);
     if (word != "{")
         throw Error("Expecterd '{'");
 
     while (1) {
-        word = Parser::extractWord(fileContent);
+        Parser::extractWord(fileContent, word);
         if (word.empty())
             throw Error("Unexpected end of file");
         if (word == "}")
@@ -34,7 +35,8 @@ Config::~Config() {
 }
 
 void Config::setListen(std::string& fileContent) {
-    std::string word = Parser::extractWord(fileContent);
+    std::string word;
+    Parser::extractWord(fileContent, word);
     if (word.empty())
         throw Error("Unexpected end of file");
 
@@ -54,13 +56,14 @@ void Config::setListen(std::string& fileContent) {
     if (this->port < 0 || this->port > 65535)
         throw Error("Invalid server port");
 
-    word = Parser::extractWord(fileContent);
+    Parser::extractWord(fileContent, word);
     if (word != ";")
         throw Error("Expected ';'");
 }
 
 void Config::setRoot(std::string& fileContent) {
-    std::string word = Parser::extractWord(fileContent);
+    std::string word;
+    Parser::extractWord(fileContent, word);
     if (word.empty())
         throw Error("Unexpected end of file");
 
@@ -69,13 +72,14 @@ void Config::setRoot(std::string& fileContent) {
 
     this->root = word;
 
-    word = Parser::extractWord(fileContent);
+    Parser::extractWord(fileContent, word);
     if (word != ";")
         throw Error("Expected ';'");
 }
 
 void Config::setMaxBodySize(std::string& fileContent) {
-    std::string word = Parser::extractWord(fileContent);
+    std::string word;
+    Parser::extractWord(fileContent, word);
     if (word.empty())
         throw Error("Unexpected end of file");
 
@@ -91,7 +95,7 @@ void Config::setMaxBodySize(std::string& fileContent) {
 
     this->maxBodySize = std::atoi(word.c_str()) * 1024 * 1024;
 
-    word = Parser::extractWord(fileContent);
+    Parser::extractWord(fileContent, word);
     if (word != ";")
         throw Error("Expected ';'");
 }

--- a/srcs/Parser.cpp
+++ b/srcs/Parser.cpp
@@ -2,25 +2,25 @@
 
 #include "Error.hpp"
 
-std::string Parser::readFile(const std::string& filename) {
+void Parser::readFile(const std::string& filename, std::string& buf) {
     std::ifstream file(filename.c_str());
     if (!file)
         throw Error(filename);
 
-    std::string fileContent((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+    buf = std::string((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
     file.close();
-
-    return fileContent;
 }
 
-std::string Parser::extractWord(std::string& str) {
+void Parser::extractWord(std::string& str, std::string& buf) {
+    buf.clear();
+
     // Skip whitespaces and comments
 
     while (1) {
         size_t start = str.find_first_not_of(" \t\n");
         if (start == std::string::npos) {
             str.clear();
-            return "";
+            return;
         }
 
         str.erase(0, start);
@@ -29,7 +29,7 @@ std::string Parser::extractWord(std::string& str) {
             size_t end = str.find_first_of("\n");
             if (end == std::string::npos) {
                 str.clear();
-                return "";
+                return;
             }
             str.erase(0, end);
         } else
@@ -37,19 +37,18 @@ std::string Parser::extractWord(std::string& str) {
     }
 
     if (str[0] == '{' || str[0] == '}' || str[0] == ';') {
-        std::string word = str.substr(0, 1);
+        buf = str[0];
         str.erase(0, 1);
-        return word;
+        return;
     }
 
     size_t end = str.find_first_of(" \t\n{};");
     if (end == std::string::npos) {
-        std::string word = str;
+        buf = str;
         str.clear();
-        return word;
+        return;
     }
 
-    std::string word = str.substr(0, end);
+    buf = str.substr(0, end);
     str.erase(0, end);
-    return word;
 }

--- a/srcs/WebServ.cpp
+++ b/srcs/WebServ.cpp
@@ -24,9 +24,9 @@ WebServ::WebServ(void) {
 }
 
 WebServ::~WebServ() {
-    for (size_t i = 0; i < WebServ::pollFds.size(); i++) {
+    size_t i = WebServ::pollFds.size();
+    while (i--)
         WebServ::removeIndex(i);
-    }
 }
 
 void WebServ::removeIndex(int index) {
@@ -49,10 +49,12 @@ void WebServ::configure(const std::string& configFile) {
 
     // Itarate words from config file
 
-    std::string fileContent = Parser::readFile(configFile);
+    std::string fileContent;
+    Parser::readFile(configFile, fileContent);
 
     while (1) {
-        std::string word = Parser::extractWord(fileContent);
+        std::string word;
+        Parser::extractWord(fileContent, word);
         if (word.empty())
             break;
 
@@ -65,13 +67,6 @@ void WebServ::configure(const std::string& configFile) {
 
 void WebServ::start(void) {
     while (1) {
-        /*
-         * poll() will wait for a fd to be ready for I/O operations
-         *
-         * If it's the SERVER_FD, it's a incoming conenction
-         * Otherwise it's incoming data from a client
-         **/
-
         int ready = poll(WebServ::pollFds.data(), WebServ::pollFds.size(), TIMEOUT);
 
         if (WebServ::quit == true)
@@ -84,7 +79,8 @@ void WebServ::start(void) {
 
         // Iterate sockets to check if there's any incoming data
 
-        for (size_t i = 0; i < WebServ::pollFds.size(); i++) {
+        size_t i = WebServ::pollFds.size();
+        while (i--) {
             if (WebServ::pollFds[i].revents & POLLIN)
                 WebServ::sockets[i]->handlePollin(i);
         }

--- a/webserv.conf
+++ b/webserv.conf
@@ -6,3 +6,10 @@ server{
     # This is a comment
     root                 ./pages/;
 }
+
+server{
+    listen               127.0.0.2:8080 ;
+    client_max_body_size 5M;
+    # This is a comment
+    root                 ./pages/;
+}


### PR DESCRIPTION
iterate the vectors from last to first is better because it prevents any bugs caused by adding or removing the current index

i also changed parser to receive a buffer as parameter so it dont need to copy the whole string twice

close #55 