### PR TITLE
fix: remove poll timeout and add flag to fcntl

### DIFF
--- a/includes/Client.hpp
+++ b/includes/Client.hpp
@@ -9,7 +9,7 @@ class Server;
 /*
  * Client class handles
  * requests and responses
- */
+ **/
 class Client : public Socket {
    public:
     Client(Server* server);

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -6,10 +6,9 @@
 #include "Socket.hpp"
 
 /*
- * Server class accepts
- * incoming connections
- * and read incoming data
- */
+ * Server class store configurations
+ * and accepts incoming connections
+ **/
 class Server : public Socket {
    public:
     Server(std::string& fileContent);

--- a/includes/WebServ.hpp
+++ b/includes/WebServ.hpp
@@ -18,7 +18,7 @@ class WebServ {
     WebServ(void);
     ~WebServ();
 
-    static std::vector<struct pollfd> pollFds;
+    static std::vector<pollfd> pollFds;
     static std::vector<Socket*> sockets;
     static bool quit;
 

--- a/srcs/Parser.cpp
+++ b/srcs/Parser.cpp
@@ -36,6 +36,8 @@ void Parser::extractWord(std::string& str, std::string& buf) {
             break;
     }
 
+    // Extract word
+
     if (str[0] == '{' || str[0] == '}' || str[0] == ';') {
         buf = str[0];
         str.erase(0, 1);

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -28,7 +28,7 @@ Server::Server(std::string& fileContent) : _config(fileContent) {
     if (setsockopt(this->_fd, SOL_SOCKET, SO_REUSEADDR, (char*)&option, sizeof(option)) == -1)
         throw Error("setsockopt");
 
-    if (fcntl(this->_fd, F_SETFL, O_NONBLOCK))
+    if (fcntl(this->_fd, F_SETFL, O_NONBLOCK, FD_CLOEXEC))
         throw Error("fcntl");
 
     struct sockaddr_in address;

--- a/srcs/WebServ.cpp
+++ b/srcs/WebServ.cpp
@@ -9,8 +9,6 @@
 #include "Parser.hpp"
 #include "Server.hpp"
 
-#define TIMEOUT 1 * 60 * 1000
-
 std::vector<pollfd> WebServ::pollFds;
 std::vector<Socket*> WebServ::sockets;
 bool WebServ::quit = false;
@@ -50,7 +48,7 @@ void WebServ::configure(const std::string& configFile) {
     struct sigaction act;
     act.sa_handler = &sighandler;
     sigfillset(&act.sa_mask);
-    act.sa_flags = SA_RESTART;
+    act.sa_flags = 0;
 
     if (sigaction(SIGINT, &act, NULL) == -1)
         throw Error("sigaction");
@@ -75,7 +73,7 @@ void WebServ::configure(const std::string& configFile) {
 
 void WebServ::start(void) {
     while (1) {
-        int ready = poll(WebServ::pollFds.data(), WebServ::pollFds.size(), TIMEOUT);
+        int ready = poll(WebServ::pollFds.data(), WebServ::pollFds.size(), -1);
 
         if (WebServ::quit == true)
             return;


### PR DESCRIPTION
the fcntl flag is needed because pdf says it

poll timeout is useless, we only wait for a fd to be available for i/o

close #59 